### PR TITLE
Fix tests and move mcap dep

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
     env:
       ROS_DISTRO: ${{ matrix.ros }}
       PIP_BREAK_SYSTEM_PACKAGES: 1
+      USE_MCAP_PIP: 1
     steps:
       - uses: actions/checkout@v4
       - uses: ros-tooling/action-ros-ci@v0.4

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ class Analyze:
         )
 
         msgs = [msg for msg in msgs_it]
-        assert len(msgs) == 1
+        assert len(msgs) >= 1
         assert msgs[0].channel.topic == "/user/cmd_vel"
 ```
 
@@ -164,6 +164,8 @@ class Run:
                         "ros2",
                         "topic",
                         "pub",
+                        "-r",
+                        "10",
                         "/user/cmd_vel",
                         "geometry_msgs/msg/Twist",
                         "{linear: {x: 1.0}, angular: {z: 0.5}}",
@@ -183,7 +185,7 @@ class AnalyzeBasicReplay:
         )
 
         msgs = [msg for msg in msgs_it]
-        assert len(msgs) == 1
+        assert len(msgs) >= 1
         assert msgs[0].channel.topic == "/user/cmd_vel"
 
 ```

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,7 @@
   <test_depend>python3-pytest</test_depend>
   <test_depend>ros2run</test_depend>
   <test_depend>ros2topic</test_depend>
-  <test_depend>mcap-ros2-support</test_depend>
+  <test_depend condition="$USE_MCAP_PIP == 1">mcap-ros2-support</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>launch</exec_depend>
-  <exec_depend>mcap-ros2-support</exec_depend>
   <exec_depend>python3-pydantic</exec_depend>
   <exec_depend>python3-termcolor</exec_depend>
   <!-- we never mention rclpy directly, but rosbag2_py in Humble doesn't specify its dependency properly -->
@@ -29,6 +28,7 @@
   <test_depend>python3-pytest</test_depend>
   <test_depend>ros2run</test_depend>
   <test_depend>ros2topic</test_depend>
+  <test_depend>mcap-ros2-support</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/test/replay_tests/basic_replay.py
+++ b/test/replay_tests/basic_replay.py
@@ -26,15 +26,13 @@ from replay_testing import (
     run,
 )
 
-cmd_vel_only_fixture = (
-    pathlib.Path(__file__).parent.parent / "fixtures" / "cmd_vel_only.mcap"
-).as_posix()
+cmd_vel_only_fixture = (pathlib.Path(__file__).parent.parent / 'fixtures' / 'cmd_vel_only.mcap').as_posix()
 
 
 @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
 class Fixtures:
-    required_input_topics = ["/vehicle/cmd_vel"]
-    expected_output_topics = ["/user/cmd_vel"]
+    required_input_topics = ['/vehicle/cmd_vel']
+    expected_output_topics = ['/user/cmd_vel']
 
 
 @run.default()
@@ -43,17 +41,17 @@ class Run:
         return LaunchDescription([
             ExecuteProcess(
                 cmd=[
-                    "ros2",
-                    "topic",
-                    "pub",
-                    "-r",
-                    "10",
-                    "/user/cmd_vel",
-                    "geometry_msgs/msg/Twist",
-                    "{linear: {x: 1.0}, angular: {z: 0.5}}",
+                    'ros2',
+                    'topic',
+                    'pub',
+                    '-r',
+                    '10',
+                    '/user/cmd_vel',
+                    'geometry_msgs/msg/Twist',
+                    '{linear: {x: 1.0}, angular: {z: 0.5}}',
                 ],
-                name="topic_pub",
-                output="screen",
+                name='topic_pub',
+                output='screen',
             )
         ])
 
@@ -61,8 +59,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
+        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
 
         msgs = [msg for msg in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == "/user/cmd_vel"
+        assert msgs[0].channel.topic == '/user/cmd_vel'

--- a/test/replay_tests/basic_replay.py
+++ b/test/replay_tests/basic_replay.py
@@ -26,13 +26,15 @@ from replay_testing import (
     run,
 )
 
-cmd_vel_only_fixture = (pathlib.Path(__file__).parent.parent / 'fixtures' / 'cmd_vel_only.mcap').as_posix()
+cmd_vel_only_fixture = (
+    pathlib.Path(__file__).parent.parent / "fixtures" / "cmd_vel_only.mcap"
+).as_posix()
 
 
 @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
 class Fixtures:
-    required_input_topics = ['/vehicle/cmd_vel']
-    expected_output_topics = ['/user/cmd_vel']
+    required_input_topics = ["/vehicle/cmd_vel"]
+    expected_output_topics = ["/user/cmd_vel"]
 
 
 @run.default()
@@ -41,17 +43,17 @@ class Run:
         return LaunchDescription([
             ExecuteProcess(
                 cmd=[
-                    'ros2',
-                    'topic',
-                    'pub',
-                    '-r',
-                    '10',
-                    '/user/cmd_vel',
-                    'geometry_msgs/msg/Twist',
-                    '{linear: {x: 1.0}, angular: {z: 0.5}}',
+                    "ros2",
+                    "topic",
+                    "pub",
+                    "-r",
+                    "10",
+                    "/user/cmd_vel",
+                    "geometry_msgs/msg/Twist",
+                    "{linear: {x: 1.0}, angular: {z: 0.5}}",
                 ],
-                name='topic_pub',
-                output='screen',
+                name="topic_pub",
+                output="screen",
             )
         ])
 
@@ -59,8 +61,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
 
         msgs = [msg for msg in msgs_it]
-        assert len(msgs) > 1
-        assert msgs[0].channel.topic == '/user/cmd_vel'
+        assert len(msgs) >= 1
+        assert msgs[0].channel.topic == "/user/cmd_vel"

--- a/test/replay_tests/basic_replay.py
+++ b/test/replay_tests/basic_replay.py
@@ -44,6 +44,8 @@ class Run:
                     'ros2',
                     'topic',
                     'pub',
+                    '-r',
+                    '10',
                     '/user/cmd_vel',
                     'geometry_msgs/msg/Twist',
                     '{linear: {x: 1.0}, angular: {z: 0.5}}',
@@ -60,5 +62,5 @@ class AnalyzeBasicReplay:
         msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
 
         msgs = [msg for msg in msgs_it]
-        assert len(msgs) == 1
+        assert len(msgs) > 1
         assert msgs[0].channel.topic == '/user/cmd_vel'

--- a/test/replay_tests/basic_replay_failure.py
+++ b/test/replay_tests/basic_replay_failure.py
@@ -26,15 +26,13 @@ from replay_testing import (
     run,
 )
 
-cmd_vel_only_fixture = (
-    pathlib.Path(__file__).parent.parent / "fixtures" / "cmd_vel_only.mcap"
-).as_posix()
+cmd_vel_only_fixture = (pathlib.Path(__file__).parent.parent / 'fixtures' / 'cmd_vel_only.mcap').as_posix()
 
 
 @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
 class FilterFixtures:
-    required_input_topics = ["/vehicle/cmd_vel"]
-    expected_output_topics = ["/user/cmd_vel"]
+    required_input_topics = ['/vehicle/cmd_vel']
+    expected_output_topics = ['/user/cmd_vel']
 
 
 @run.default()
@@ -43,17 +41,17 @@ class Run:
         return LaunchDescription([
             ExecuteProcess(
                 cmd=[
-                    "ros2",
-                    "topic",
-                    "pub",
-                    "-r",
-                    "10",
-                    "/user/cmd_vel",
-                    "geometry_msgs/msg/Twist",
-                    "{linear: {x: 1.0}, angular: {z: 0.5}}",
+                    'ros2',
+                    'topic',
+                    'pub',
+                    '-r',
+                    '10',
+                    '/user/cmd_vel',
+                    'geometry_msgs/msg/Twist',
+                    '{linear: {x: 1.0}, angular: {z: 0.5}}',
                 ],
-                name="topic_pub",
-                output="screen",
+                name='topic_pub',
+                output='screen',
             )
         ])
 
@@ -61,8 +59,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_expected_failure(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
+        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
 
         msgs = [msg for msg in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == "/nonexistent/cmd_vel"
+        assert msgs[0].channel.topic == '/nonexistent/cmd_vel'

--- a/test/replay_tests/basic_replay_failure.py
+++ b/test/replay_tests/basic_replay_failure.py
@@ -26,13 +26,15 @@ from replay_testing import (
     run,
 )
 
-cmd_vel_only_fixture = (pathlib.Path(__file__).parent.parent / 'fixtures' / 'cmd_vel_only.mcap').as_posix()
+cmd_vel_only_fixture = (
+    pathlib.Path(__file__).parent.parent / "fixtures" / "cmd_vel_only.mcap"
+).as_posix()
 
 
 @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
 class FilterFixtures:
-    required_input_topics = ['/vehicle/cmd_vel']
-    expected_output_topics = ['/user/cmd_vel']
+    required_input_topics = ["/vehicle/cmd_vel"]
+    expected_output_topics = ["/user/cmd_vel"]
 
 
 @run.default()
@@ -41,15 +43,17 @@ class Run:
         return LaunchDescription([
             ExecuteProcess(
                 cmd=[
-                    'ros2',
-                    'topic',
-                    'pub',
-                    '/user/cmd_vel',
-                    'geometry_msgs/msg/Twist',
-                    '{linear: {x: 1.0}, angular: {z: 0.5}}',
+                    "ros2",
+                    "topic",
+                    "pub",
+                    "-r",
+                    "10",
+                    "/user/cmd_vel",
+                    "geometry_msgs/msg/Twist",
+                    "{linear: {x: 1.0}, angular: {z: 0.5}}",
                 ],
-                name='topic_pub',
-                output='screen',
+                name="topic_pub",
+                output="screen",
             )
         ])
 
@@ -57,8 +61,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_expected_failure(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
 
         msgs = [msg for msg in msgs_it]
-        assert len(msgs) == 1
-        assert msgs[0].channel.topic == '/nonexistent/cmd_vel'
+        assert len(msgs) >= 1
+        assert msgs[0].channel.topic == "/nonexistent/cmd_vel"

--- a/test/replay_tests/basic_replay_multiple_fixtures_and_params.py
+++ b/test/replay_tests/basic_replay_multiple_fixtures_and_params.py
@@ -29,10 +29,10 @@ from replay_testing import (
     run,
 )
 
-replay_testing_dir = get_package_share_directory('replay_testing')
+replay_testing_dir = get_package_share_directory("replay_testing")
 
-cmd_vel_only_fixture = os.path.join(replay_testing_dir, 'test', 'fixtures', 'cmd_vel_only.mcap')
-cmd_vel_only_2_fixture = os.path.join(replay_testing_dir, 'test', 'fixtures', 'cmd_vel_only_2.mcap')
+cmd_vel_only_fixture = os.path.join(replay_testing_dir, "test", "fixtures", "cmd_vel_only.mcap")
+cmd_vel_only_2_fixture = os.path.join(replay_testing_dir, "test", "fixtures", "cmd_vel_only_2.mcap")
 
 
 @fixtures.parameterize([
@@ -40,33 +40,35 @@ cmd_vel_only_2_fixture = os.path.join(replay_testing_dir, 'test', 'fixtures', 'c
     McapFixture(path=cmd_vel_only_2_fixture),
 ])
 class Fixtures:
-    required_input_topics = ['/vehicle/cmd_vel']
-    expected_output_topics = ['/user/cmd_vel']
+    required_input_topics = ["/vehicle/cmd_vel"]
+    expected_output_topics = ["/user/cmd_vel"]
 
 
 @run.parameterize([
-    ReplayRunParams(name='run_1_twist_slow', params={'x': 1.0}),
-    ReplayRunParams(name='run_2_twist_fast', params={'x': 10.0}),
+    ReplayRunParams(name="run_1_twist_slow", params={"x": 1.0}),
+    ReplayRunParams(name="run_2_twist_fast", params={"x": 10.0}),
 ])
 class Run:
     def generate_launch_description(self, replay_run_params: ReplayRunParams) -> LaunchDescription:
-        print('replay_run_parms')
+        print("replay_run_parms")
         twist_msg = {
-            'linear': {'x': replay_run_params.params['x']},
-            'angular': {'z': 0.5},
+            "linear": {"x": replay_run_params.params["x"]},
+            "angular": {"z": 0.5},
         }
         return LaunchDescription([
             ExecuteProcess(
                 cmd=[
-                    'ros2',
-                    'topic',
-                    'pub',
-                    '/user/cmd_vel',
-                    'geometry_msgs/msg/Twist',
+                    "ros2",
+                    "topic",
+                    "pub",
+                    "-r",
+                    "10",
+                    "/user/cmd_vel",
+                    "geometry_msgs/msg/Twist",
                     json.dumps(twist_msg),
                 ],
-                name='topic_pub',
-                output='screen',
+                name="topic_pub",
+                output="screen",
             )
         ])
 
@@ -74,8 +76,8 @@ class Run:
 @analyze
 class Analyze:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
 
         msgs = [msg for msg in msgs_it]
-        assert len(msgs) == 1
-        assert msgs[0].channel.topic == '/user/cmd_vel'
+        assert len(msgs) >= 1
+        assert msgs[0].channel.topic == "/user/cmd_vel"

--- a/test/replay_tests/basic_replay_multiple_fixtures_and_params.py
+++ b/test/replay_tests/basic_replay_multiple_fixtures_and_params.py
@@ -29,10 +29,10 @@ from replay_testing import (
     run,
 )
 
-replay_testing_dir = get_package_share_directory("replay_testing")
+replay_testing_dir = get_package_share_directory('replay_testing')
 
-cmd_vel_only_fixture = os.path.join(replay_testing_dir, "test", "fixtures", "cmd_vel_only.mcap")
-cmd_vel_only_2_fixture = os.path.join(replay_testing_dir, "test", "fixtures", "cmd_vel_only_2.mcap")
+cmd_vel_only_fixture = os.path.join(replay_testing_dir, 'test', 'fixtures', 'cmd_vel_only.mcap')
+cmd_vel_only_2_fixture = os.path.join(replay_testing_dir, 'test', 'fixtures', 'cmd_vel_only_2.mcap')
 
 
 @fixtures.parameterize([
@@ -40,35 +40,35 @@ cmd_vel_only_2_fixture = os.path.join(replay_testing_dir, "test", "fixtures", "c
     McapFixture(path=cmd_vel_only_2_fixture),
 ])
 class Fixtures:
-    required_input_topics = ["/vehicle/cmd_vel"]
-    expected_output_topics = ["/user/cmd_vel"]
+    required_input_topics = ['/vehicle/cmd_vel']
+    expected_output_topics = ['/user/cmd_vel']
 
 
 @run.parameterize([
-    ReplayRunParams(name="run_1_twist_slow", params={"x": 1.0}),
-    ReplayRunParams(name="run_2_twist_fast", params={"x": 10.0}),
+    ReplayRunParams(name='run_1_twist_slow', params={'x': 1.0}),
+    ReplayRunParams(name='run_2_twist_fast', params={'x': 10.0}),
 ])
 class Run:
     def generate_launch_description(self, replay_run_params: ReplayRunParams) -> LaunchDescription:
-        print("replay_run_parms")
+        print('replay_run_parms')
         twist_msg = {
-            "linear": {"x": replay_run_params.params["x"]},
-            "angular": {"z": 0.5},
+            'linear': {'x': replay_run_params.params['x']},
+            'angular': {'z': 0.5},
         }
         return LaunchDescription([
             ExecuteProcess(
                 cmd=[
-                    "ros2",
-                    "topic",
-                    "pub",
-                    "-r",
-                    "10",
-                    "/user/cmd_vel",
-                    "geometry_msgs/msg/Twist",
+                    'ros2',
+                    'topic',
+                    'pub',
+                    '-r',
+                    '10',
+                    '/user/cmd_vel',
+                    'geometry_msgs/msg/Twist',
                     json.dumps(twist_msg),
                 ],
-                name="topic_pub",
-                output="screen",
+                name='topic_pub',
+                output='screen',
             )
         ])
 
@@ -76,8 +76,8 @@ class Run:
 @analyze
 class Analyze:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
+        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
 
         msgs = [msg for msg in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == "/user/cmd_vel"
+        assert msgs[0].channel.topic == '/user/cmd_vel'

--- a/test/replay_tests/nexus_replay.py
+++ b/test/replay_tests/nexus_replay.py
@@ -20,10 +20,10 @@ from launch.actions import ExecuteProcess
 from replay_testing import NexusFixture, analyze, fixtures, run
 
 
-@fixtures.parameterize([NexusFixture(path='generic/cmd_vel_only.mcap')])
+@fixtures.parameterize([NexusFixture(path="generic/cmd_vel_only.mcap")])
 class Fixtures:
-    required_input_topics = ['/vehicle/cmd_vel']
-    expected_output_topics = ['/user/cmd_vel']
+    required_input_topics = ["/vehicle/cmd_vel"]
+    expected_output_topics = ["/user/cmd_vel"]
 
 
 @run.default()
@@ -32,15 +32,17 @@ class Run:
         return LaunchDescription([
             ExecuteProcess(
                 cmd=[
-                    'ros2',
-                    'topic',
-                    'pub',
-                    '/user/cmd_vel',
-                    'geometry_msgs/msg/Twist',
-                    '{linear: {x: 1.0}, angular: {z: 0.5}}',
+                    "ros2",
+                    "topic",
+                    "pub",
+                    "-r",
+                    "10",
+                    "/user/cmd_vel",
+                    "geometry_msgs/msg/Twist",
+                    "{linear: {x: 1.0}, angular: {z: 0.5}}",
                 ],
-                name='topic_pub',
-                output='screen',
+                name="topic_pub",
+                output="screen",
             )
         ])
 
@@ -48,8 +50,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
 
         msgs = [msg for msg in msgs_it]
-        assert len(msgs) == 1
-        assert msgs[0].channel.topic == '/user/cmd_vel'
+        assert len(msgs) >= 1
+        assert msgs[0].channel.topic == "/user/cmd_vel"

--- a/test/replay_tests/nexus_replay.py
+++ b/test/replay_tests/nexus_replay.py
@@ -20,10 +20,10 @@ from launch.actions import ExecuteProcess
 from replay_testing import NexusFixture, analyze, fixtures, run
 
 
-@fixtures.parameterize([NexusFixture(path="generic/cmd_vel_only.mcap")])
+@fixtures.parameterize([NexusFixture(path='generic/cmd_vel_only.mcap')])
 class Fixtures:
-    required_input_topics = ["/vehicle/cmd_vel"]
-    expected_output_topics = ["/user/cmd_vel"]
+    required_input_topics = ['/vehicle/cmd_vel']
+    expected_output_topics = ['/user/cmd_vel']
 
 
 @run.default()
@@ -32,17 +32,17 @@ class Run:
         return LaunchDescription([
             ExecuteProcess(
                 cmd=[
-                    "ros2",
-                    "topic",
-                    "pub",
-                    "-r",
-                    "10",
-                    "/user/cmd_vel",
-                    "geometry_msgs/msg/Twist",
-                    "{linear: {x: 1.0}, angular: {z: 0.5}}",
+                    'ros2',
+                    'topic',
+                    'pub',
+                    '-r',
+                    '10',
+                    '/user/cmd_vel',
+                    'geometry_msgs/msg/Twist',
+                    '{linear: {x: 1.0}, angular: {z: 0.5}}',
                 ],
-                name="topic_pub",
-                output="screen",
+                name='topic_pub',
+                output='screen',
             )
         ])
 
@@ -50,8 +50,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
+        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
 
         msgs = [msg for msg in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == "/user/cmd_vel"
+        assert msgs[0].channel.topic == '/user/cmd_vel'

--- a/test/test_replay_runner.py
+++ b/test/test_replay_runner.py
@@ -34,18 +34,18 @@ from replay_testing import (
     run,
 )
 
-replay_testing_dir = get_package_share_directory("replay_testing")
+replay_testing_dir = get_package_share_directory('replay_testing')
 
-cmd_vel_only_fixture = os.path.join(replay_testing_dir, "test", "fixtures", "cmd_vel_only.mcap")
-cmd_vel_only_2_fixture = os.path.join(replay_testing_dir, "test", "fixtures", "cmd_vel_only_2.mcap")
+cmd_vel_only_fixture = os.path.join(replay_testing_dir, 'test', 'fixtures', 'cmd_vel_only.mcap')
+cmd_vel_only_2_fixture = os.path.join(replay_testing_dir, 'test', 'fixtures', 'cmd_vel_only_2.mcap')
 
 
 def test_fixtures():
-    test_module = types.ModuleType("test_module")
+    test_module = types.ModuleType('test_module')
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ["/vehicle/cmd_vel"]
+        required_input_topics = ['/vehicle/cmd_vel']
         expected_output_topics = []
 
     test_module.Fixtures = Fixtures
@@ -60,16 +60,16 @@ def test_fixtures():
     topics = reader.get_all_topics_and_types()
 
     assert len(topics) == 1
-    assert topics[0].name == "/vehicle/cmd_vel"
+    assert topics[0].name == '/vehicle/cmd_vel'
     return
 
 
 def test_fixtures_raises_err():
-    test_module = types.ModuleType("test_module")
+    test_module = types.ModuleType('test_module')
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ["/vehicle/cmd_vel", "/does_not_exist"]
+        required_input_topics = ['/vehicle/cmd_vel', '/does_not_exist']
         expected_output_topics = []
 
     test_module.Fixtures = Fixtures
@@ -80,12 +80,12 @@ def test_fixtures_raises_err():
 
 
 def test_run():
-    test_module = types.ModuleType("test_module")
+    test_module = types.ModuleType('test_module')
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ["/vehicle/cmd_vel"]
-        expected_output_topics = ["/user/cmd_vel"]
+        required_input_topics = ['/vehicle/cmd_vel']
+        expected_output_topics = ['/user/cmd_vel']
 
     @run.default()
     class Run:
@@ -93,17 +93,17 @@ def test_run():
             return LaunchDescription([
                 ExecuteProcess(
                     cmd=[
-                        "ros2",
-                        "topic",
-                        "pub",
-                        "-r",
-                        "10",
-                        "/user/cmd_vel",
-                        "geometry_msgs/msg/Twist",
-                        "{linear: {x: 1.0}, angular: {z: 0.5}}",
+                        'ros2',
+                        'topic',
+                        'pub',
+                        '-r',
+                        '10',
+                        '/user/cmd_vel',
+                        'geometry_msgs/msg/Twist',
+                        '{linear: {x: 1.0}, angular: {z: 0.5}}',
                     ],
-                    name="topic_pub",
-                    output="screen",
+                    name='topic_pub',
+                    output='screen',
                 )
             ])
 
@@ -121,25 +121,25 @@ def test_run():
     topics = reader.get_all_topics_and_types()
     topic_names = [topic.name for topic in topics]
 
-    assert "/vehicle/cmd_vel" in topic_names
-    assert "/user/cmd_vel" in topic_names
+    assert '/vehicle/cmd_vel' in topic_names
+    assert '/user/cmd_vel' in topic_names
 
     msg_reader = get_message_mcap_reader(run_fixture.path)
-    msgs_it = mcap_ros2.reader.read_ros2_messages(msg_reader, topics=["/user/cmd_vel"])
+    msgs_it = mcap_ros2.reader.read_ros2_messages(msg_reader, topics=['/user/cmd_vel'])
 
     msgs = [msg for msg in msgs_it]
     assert len(msgs) >= 1
-    assert msgs[0].channel.topic == "/user/cmd_vel"
+    assert msgs[0].channel.topic == '/user/cmd_vel'
     return
 
 
 def test_analyze():
-    test_module = types.ModuleType("test_module")
+    test_module = types.ModuleType('test_module')
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ["/vehicle/cmd_vel"]
-        expected_output_topics = ["/user/cmd_vel"]
+        required_input_topics = ['/vehicle/cmd_vel']
+        expected_output_topics = ['/user/cmd_vel']
 
     @run.default()
     class Run:
@@ -147,28 +147,28 @@ def test_analyze():
             return LaunchDescription([
                 ExecuteProcess(
                     cmd=[
-                        "ros2",
-                        "topic",
-                        "pub",
-                        "-r",
-                        "10",
-                        "/user/cmd_vel",
-                        "geometry_msgs/msg/Twist",
-                        "{linear: {x: 1.0}, angular: {z: 0.5}}",
+                        'ros2',
+                        'topic',
+                        'pub',
+                        '-r',
+                        '10',
+                        '/user/cmd_vel',
+                        'geometry_msgs/msg/Twist',
+                        '{linear: {x: 1.0}, angular: {z: 0.5}}',
                     ],
-                    name="topic_pub",
-                    output="screen",
+                    name='topic_pub',
+                    output='screen',
                 )
             ])
 
     @analyze
     class Analyze:
         def test_cmd_vel(self):
-            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
+            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
 
             msgs = [msg for msg in msgs_it]
             assert len(msgs) >= 1
-            assert msgs[0].channel.topic == "/user/cmd_vel"
+            assert msgs[0].channel.topic == '/user/cmd_vel'
 
     test_module.Fixtures = Fixtures
     test_module.Run = Run
@@ -184,12 +184,12 @@ def test_analyze():
 
 
 def test_failed_analyze():
-    test_module = types.ModuleType("test_module")
+    test_module = types.ModuleType('test_module')
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ["/vehicle/cmd_vel"]
-        expected_output_topics = ["/user/cmd_vel"]
+        required_input_topics = ['/vehicle/cmd_vel']
+        expected_output_topics = ['/user/cmd_vel']
 
     @run.default()
     class Run:
@@ -197,17 +197,17 @@ def test_failed_analyze():
             return LaunchDescription([
                 ExecuteProcess(
                     cmd=[
-                        "ros2",
-                        "topic",
-                        "pub",
-                        "-r",
-                        "10",
-                        "/user/cmd_vel",
-                        "geometry_msgs/msg/Twist",
-                        "{linear: {x: 1.0}, angular: {z: 0.5}}",
+                        'ros2',
+                        'topic',
+                        'pub',
+                        '-r',
+                        '10',
+                        '/user/cmd_vel',
+                        'geometry_msgs/msg/Twist',
+                        '{linear: {x: 1.0}, angular: {z: 0.5}}',
                     ],
-                    name="topic_pub",
-                    output="screen",
+                    name='topic_pub',
+                    output='screen',
                 )
             ])
 
@@ -230,15 +230,15 @@ def test_failed_analyze():
 
 
 def test_multiple_fixtures():
-    test_module = types.ModuleType("test_module")
+    test_module = types.ModuleType('test_module')
 
     @fixtures.parameterize([
         McapFixture(path=cmd_vel_only_fixture),
         McapFixture(path=cmd_vel_only_2_fixture),
     ])
     class Fixtures:
-        required_input_topics = ["/vehicle/cmd_vel"]
-        expected_output_topics = ["/user/cmd_vel"]
+        required_input_topics = ['/vehicle/cmd_vel']
+        expected_output_topics = ['/user/cmd_vel']
 
     @run.default()
     class Run:
@@ -246,28 +246,28 @@ def test_multiple_fixtures():
             return LaunchDescription([
                 ExecuteProcess(
                     cmd=[
-                        "ros2",
-                        "topic",
-                        "pub",
-                        "-r",
-                        "10",
-                        "/user/cmd_vel",
-                        "geometry_msgs/msg/Twist",
-                        "{linear: {x: 1.0}, angular: {z: 0.5}}",
+                        'ros2',
+                        'topic',
+                        'pub',
+                        '-r',
+                        '10',
+                        '/user/cmd_vel',
+                        'geometry_msgs/msg/Twist',
+                        '{linear: {x: 1.0}, angular: {z: 0.5}}',
                     ],
-                    name="topic_pub",
-                    output="screen",
+                    name='topic_pub',
+                    output='screen',
                 )
             ])
 
     @analyze
     class Analyze:
         def test_cmd_vel(self):
-            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
+            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
 
             msgs = [msg for msg in msgs_it]
             assert len(msgs) >= 1
-            assert msgs[0].channel.topic == "/user/cmd_vel"
+            assert msgs[0].channel.topic == '/user/cmd_vel'
 
     test_module.Fixtures = Fixtures
     test_module.Run = Run
@@ -291,51 +291,49 @@ def test_multiple_fixtures():
 
 
 def test_parametric_sweep():
-    test_module = types.ModuleType("test_module")
+    test_module = types.ModuleType('test_module')
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ["/vehicle/cmd_vel"]
-        expected_output_topics = ["/user/cmd_vel"]
+        required_input_topics = ['/vehicle/cmd_vel']
+        expected_output_topics = ['/user/cmd_vel']
 
     @run.parameterize([
-        ReplayRunParams(name="run_1_twist_slow", params={"x": 1.0}),
-        ReplayRunParams(name="run_2_twist_fast", params={"x": 10.0}),
+        ReplayRunParams(name='run_1_twist_slow', params={'x': 1.0}),
+        ReplayRunParams(name='run_2_twist_fast', params={'x': 10.0}),
     ])
     class Run:
-        def generate_launch_description(
-            self, replay_run_params: ReplayRunParams
-        ) -> LaunchDescription:
-            print("replay_run_parms")
+        def generate_launch_description(self, replay_run_params: ReplayRunParams) -> LaunchDescription:
+            print('replay_run_parms')
             twist_msg = {
-                "linear": {"x": replay_run_params.params["x"]},
-                "angular": {"z": 0.5},
+                'linear': {'x': replay_run_params.params['x']},
+                'angular': {'z': 0.5},
             }
             return LaunchDescription([
                 ExecuteProcess(
                     cmd=[
-                        "ros2",
-                        "topic",
-                        "pub",
-                        "-r",
-                        "10",
-                        "/user/cmd_vel",
-                        "geometry_msgs/msg/Twist",
+                        'ros2',
+                        'topic',
+                        'pub',
+                        '-r',
+                        '10',
+                        '/user/cmd_vel',
+                        'geometry_msgs/msg/Twist',
                         json.dumps(twist_msg),
                     ],
-                    name="topic_pub",
-                    output="screen",
+                    name='topic_pub',
+                    output='screen',
                 )
             ])
 
     @analyze
     class Analyze:
         def test_cmd_vel(self):
-            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
+            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
 
             msgs = [msg for msg in msgs_it]
             assert len(msgs) >= 1
-            assert msgs[0].channel.topic == "/user/cmd_vel"
+            assert msgs[0].channel.topic == '/user/cmd_vel'
 
     test_module.Fixtures = Fixtures
     test_module.Run = Run

--- a/test/test_replay_runner.py
+++ b/test/test_replay_runner.py
@@ -34,18 +34,18 @@ from replay_testing import (
     run,
 )
 
-replay_testing_dir = get_package_share_directory('replay_testing')
+replay_testing_dir = get_package_share_directory("replay_testing")
 
-cmd_vel_only_fixture = os.path.join(replay_testing_dir, 'test', 'fixtures', 'cmd_vel_only.mcap')
-cmd_vel_only_2_fixture = os.path.join(replay_testing_dir, 'test', 'fixtures', 'cmd_vel_only_2.mcap')
+cmd_vel_only_fixture = os.path.join(replay_testing_dir, "test", "fixtures", "cmd_vel_only.mcap")
+cmd_vel_only_2_fixture = os.path.join(replay_testing_dir, "test", "fixtures", "cmd_vel_only_2.mcap")
 
 
 def test_fixtures():
-    test_module = types.ModuleType('test_module')
+    test_module = types.ModuleType("test_module")
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ['/vehicle/cmd_vel']
+        required_input_topics = ["/vehicle/cmd_vel"]
         expected_output_topics = []
 
     test_module.Fixtures = Fixtures
@@ -60,16 +60,16 @@ def test_fixtures():
     topics = reader.get_all_topics_and_types()
 
     assert len(topics) == 1
-    assert topics[0].name == '/vehicle/cmd_vel'
+    assert topics[0].name == "/vehicle/cmd_vel"
     return
 
 
 def test_fixtures_raises_err():
-    test_module = types.ModuleType('test_module')
+    test_module = types.ModuleType("test_module")
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ['/vehicle/cmd_vel', '/does_not_exist']
+        required_input_topics = ["/vehicle/cmd_vel", "/does_not_exist"]
         expected_output_topics = []
 
     test_module.Fixtures = Fixtures
@@ -80,12 +80,12 @@ def test_fixtures_raises_err():
 
 
 def test_run():
-    test_module = types.ModuleType('test_module')
+    test_module = types.ModuleType("test_module")
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ['/vehicle/cmd_vel']
-        expected_output_topics = ['/user/cmd_vel']
+        required_input_topics = ["/vehicle/cmd_vel"]
+        expected_output_topics = ["/user/cmd_vel"]
 
     @run.default()
     class Run:
@@ -93,15 +93,17 @@ def test_run():
             return LaunchDescription([
                 ExecuteProcess(
                     cmd=[
-                        'ros2',
-                        'topic',
-                        'pub',
-                        '/user/cmd_vel',
-                        'geometry_msgs/msg/Twist',
-                        '{linear: {x: 1.0}, angular: {z: 0.5}}',
+                        "ros2",
+                        "topic",
+                        "pub",
+                        "-r",
+                        "10",
+                        "/user/cmd_vel",
+                        "geometry_msgs/msg/Twist",
+                        "{linear: {x: 1.0}, angular: {z: 0.5}}",
                     ],
-                    name='topic_pub',
-                    output='screen',
+                    name="topic_pub",
+                    output="screen",
                 )
             ])
 
@@ -119,25 +121,25 @@ def test_run():
     topics = reader.get_all_topics_and_types()
     topic_names = [topic.name for topic in topics]
 
-    assert '/vehicle/cmd_vel' in topic_names
-    assert '/user/cmd_vel' in topic_names
+    assert "/vehicle/cmd_vel" in topic_names
+    assert "/user/cmd_vel" in topic_names
 
     msg_reader = get_message_mcap_reader(run_fixture.path)
-    msgs_it = mcap_ros2.reader.read_ros2_messages(msg_reader, topics=['/user/cmd_vel'])
+    msgs_it = mcap_ros2.reader.read_ros2_messages(msg_reader, topics=["/user/cmd_vel"])
 
     msgs = [msg for msg in msgs_it]
-    assert len(msgs) == 1
-    assert msgs[0].channel.topic == '/user/cmd_vel'
+    assert len(msgs) >= 1
+    assert msgs[0].channel.topic == "/user/cmd_vel"
     return
 
 
 def test_analyze():
-    test_module = types.ModuleType('test_module')
+    test_module = types.ModuleType("test_module")
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ['/vehicle/cmd_vel']
-        expected_output_topics = ['/user/cmd_vel']
+        required_input_topics = ["/vehicle/cmd_vel"]
+        expected_output_topics = ["/user/cmd_vel"]
 
     @run.default()
     class Run:
@@ -145,26 +147,28 @@ def test_analyze():
             return LaunchDescription([
                 ExecuteProcess(
                     cmd=[
-                        'ros2',
-                        'topic',
-                        'pub',
-                        '/user/cmd_vel',
-                        'geometry_msgs/msg/Twist',
-                        '{linear: {x: 1.0}, angular: {z: 0.5}}',
+                        "ros2",
+                        "topic",
+                        "pub",
+                        "-r",
+                        "10",
+                        "/user/cmd_vel",
+                        "geometry_msgs/msg/Twist",
+                        "{linear: {x: 1.0}, angular: {z: 0.5}}",
                     ],
-                    name='topic_pub',
-                    output='screen',
+                    name="topic_pub",
+                    output="screen",
                 )
             ])
 
     @analyze
     class Analyze:
         def test_cmd_vel(self):
-            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
 
             msgs = [msg for msg in msgs_it]
-            assert len(msgs) == 1
-            assert msgs[0].channel.topic == '/user/cmd_vel'
+            assert len(msgs) >= 1
+            assert msgs[0].channel.topic == "/user/cmd_vel"
 
     test_module.Fixtures = Fixtures
     test_module.Run = Run
@@ -180,12 +184,12 @@ def test_analyze():
 
 
 def test_failed_analyze():
-    test_module = types.ModuleType('test_module')
+    test_module = types.ModuleType("test_module")
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ['/vehicle/cmd_vel']
-        expected_output_topics = ['/user/cmd_vel']
+        required_input_topics = ["/vehicle/cmd_vel"]
+        expected_output_topics = ["/user/cmd_vel"]
 
     @run.default()
     class Run:
@@ -193,15 +197,17 @@ def test_failed_analyze():
             return LaunchDescription([
                 ExecuteProcess(
                     cmd=[
-                        'ros2',
-                        'topic',
-                        'pub',
-                        '/user/cmd_vel',
-                        'geometry_msgs/msg/Twist',
-                        '{linear: {x: 1.0}, angular: {z: 0.5}}',
+                        "ros2",
+                        "topic",
+                        "pub",
+                        "-r",
+                        "10",
+                        "/user/cmd_vel",
+                        "geometry_msgs/msg/Twist",
+                        "{linear: {x: 1.0}, angular: {z: 0.5}}",
                     ],
-                    name='topic_pub',
-                    output='screen',
+                    name="topic_pub",
+                    output="screen",
                 )
             ])
 
@@ -224,15 +230,15 @@ def test_failed_analyze():
 
 
 def test_multiple_fixtures():
-    test_module = types.ModuleType('test_module')
+    test_module = types.ModuleType("test_module")
 
     @fixtures.parameterize([
         McapFixture(path=cmd_vel_only_fixture),
         McapFixture(path=cmd_vel_only_2_fixture),
     ])
     class Fixtures:
-        required_input_topics = ['/vehicle/cmd_vel']
-        expected_output_topics = ['/user/cmd_vel']
+        required_input_topics = ["/vehicle/cmd_vel"]
+        expected_output_topics = ["/user/cmd_vel"]
 
     @run.default()
     class Run:
@@ -240,26 +246,28 @@ def test_multiple_fixtures():
             return LaunchDescription([
                 ExecuteProcess(
                     cmd=[
-                        'ros2',
-                        'topic',
-                        'pub',
-                        '/user/cmd_vel',
-                        'geometry_msgs/msg/Twist',
-                        '{linear: {x: 1.0}, angular: {z: 0.5}}',
+                        "ros2",
+                        "topic",
+                        "pub",
+                        "-r",
+                        "10",
+                        "/user/cmd_vel",
+                        "geometry_msgs/msg/Twist",
+                        "{linear: {x: 1.0}, angular: {z: 0.5}}",
                     ],
-                    name='topic_pub',
-                    output='screen',
+                    name="topic_pub",
+                    output="screen",
                 )
             ])
 
     @analyze
     class Analyze:
         def test_cmd_vel(self):
-            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
 
             msgs = [msg for msg in msgs_it]
-            assert len(msgs) == 1
-            assert msgs[0].channel.topic == '/user/cmd_vel'
+            assert len(msgs) >= 1
+            assert msgs[0].channel.topic == "/user/cmd_vel"
 
     test_module.Fixtures = Fixtures
     test_module.Run = Run
@@ -283,47 +291,51 @@ def test_multiple_fixtures():
 
 
 def test_parametric_sweep():
-    test_module = types.ModuleType('test_module')
+    test_module = types.ModuleType("test_module")
 
     @fixtures.parameterize([McapFixture(path=cmd_vel_only_fixture)])
     class Fixtures:
-        required_input_topics = ['/vehicle/cmd_vel']
-        expected_output_topics = ['/user/cmd_vel']
+        required_input_topics = ["/vehicle/cmd_vel"]
+        expected_output_topics = ["/user/cmd_vel"]
 
     @run.parameterize([
-        ReplayRunParams(name='run_1_twist_slow', params={'x': 1.0}),
-        ReplayRunParams(name='run_2_twist_fast', params={'x': 10.0}),
+        ReplayRunParams(name="run_1_twist_slow", params={"x": 1.0}),
+        ReplayRunParams(name="run_2_twist_fast", params={"x": 10.0}),
     ])
     class Run:
-        def generate_launch_description(self, replay_run_params: ReplayRunParams) -> LaunchDescription:
-            print('replay_run_parms')
+        def generate_launch_description(
+            self, replay_run_params: ReplayRunParams
+        ) -> LaunchDescription:
+            print("replay_run_parms")
             twist_msg = {
-                'linear': {'x': replay_run_params.params['x']},
-                'angular': {'z': 0.5},
+                "linear": {"x": replay_run_params.params["x"]},
+                "angular": {"z": 0.5},
             }
             return LaunchDescription([
                 ExecuteProcess(
                     cmd=[
-                        'ros2',
-                        'topic',
-                        'pub',
-                        '/user/cmd_vel',
-                        'geometry_msgs/msg/Twist',
+                        "ros2",
+                        "topic",
+                        "pub",
+                        "-r",
+                        "10",
+                        "/user/cmd_vel",
+                        "geometry_msgs/msg/Twist",
                         json.dumps(twist_msg),
                     ],
-                    name='topic_pub',
-                    output='screen',
+                    name="topic_pub",
+                    output="screen",
                 )
             ])
 
     @analyze
     class Analyze:
         def test_cmd_vel(self):
-            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=["/user/cmd_vel"])
 
             msgs = [msg for msg in msgs_it]
-            assert len(msgs) == 1
-            assert msgs[0].channel.topic == '/user/cmd_vel'
+            assert len(msgs) >= 1
+            assert msgs[0].channel.topic == "/user/cmd_vel"
 
     test_module.Fixtures = Fixtures
     test_module.Run = Run


### PR DESCRIPTION
## Description

Resolves #3 by increasing the publish rate, as suspected there are some timing differences from Humble. Wrote https://github.com/polymathrobotics/replay_testing/issues/5 to follow up on a better test-case for documentation. This one is a bit contrived.

Currently the mcap ros reader is only used in test files and examples in the repo. Re-declaring it as a test dependency. 