### PR TITLE
Remove reliance on `mcap-ros2-support`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,20 +36,16 @@ install(
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   include(cmake/add_replay_test.cmake)
+  ament_add_pytest_test(pytest ${CMAKE_CURRENT_SOURCE_DIR}/test)
 
-  # TODO(troy): Once https://github.com/polymathrobotics/replay_testing/issues/2 is resolved, remove.
-  if($ENV{USE_MCAP_PIP})
-    ament_add_pytest_test(pytest ${CMAKE_CURRENT_SOURCE_DIR}/test)
+  add_replay_test(test/replay_tests/basic_replay.py)
 
-    add_replay_test(test/replay_tests/basic_replay.py)
+  if($ENV{AWS_BUCKET})
+    add_replay_test(test/replay_tests/s3_replay.py)
+  endif()
 
-    if($ENV{AWS_BUCKET})
-      add_replay_test(test/replay_tests/s3_replay.py)
-    endif()
-
-    if($ENV{USE_NEXUS})
-      add_replay_test(test/replay_tests/nexus_replay.py)
-    endif()
+  if($ENV{USE_NEXUS})
+    add_replay_test(test/replay_tests/nexus_replay.py)
   endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -135,21 +135,23 @@ When `use_clock=False`, the replay will:
 
 The analyze step is run after the mcap from the `run` is recorded and written. It is a basic wrapper over `unittest.TestCase`, so any `unittest` assertions are built in.
 
-It also wraps an initialized MCAP reader `self.reader` ([MCAP docs](https://mcap.dev/docs/python/mcap-ros2-apidoc/mcap_ros2.reader)) that you can use to assert against expected message output.
+It also wraps an initialized MCAP reader `self.reader` (a `rosbag2_py.SequentialReader`) that you can use to assert against expected message output.
 
 Example:
 
 ```python
+from replay_testing import read_messages
+
 @analyze
 class Analyze:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(
+        msgs_it = read_messages(
             self.reader, topics=["/user/cmd_vel"]
         )
 
-        msgs = [msg for msg in msgs_it]
+        msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == "/user/cmd_vel"
+        assert msgs[0][0] == "/user/cmd_vel"
 ```
 
 ### Full Example
@@ -160,11 +162,11 @@ from replay_testing import (
     run,
     analyze,
     McapFixture,
+    read_messages,
 )
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 
-import mcap_ros2.reader
 import pathlib
 
 
@@ -201,13 +203,13 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(
+        msgs_it = read_messages(
             self.reader, topics=["/user/cmd_vel"]
         )
 
-        msgs = [msg for msg in msgs_it]
+        msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == "/user/cmd_vel"
+        assert msgs[0][0] == "/user/cmd_vel"
 
 ```
 

--- a/package.xml
+++ b/package.xml
@@ -29,8 +29,6 @@
   <test_depend>python3-pytest</test_depend>
   <test_depend>ros2run</test_depend>
   <test_depend>ros2topic</test_depend>
-  <!-- TODO(troy): Once https://github.com/polymathrobotics/replay_testing/issues/2 is resolved, remove. -->
-  <test_depend condition="$USE_MCAP_PIP == 1">mcap-ros2-support</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/replay_testing/__init__.py
+++ b/replay_testing/__init__.py
@@ -19,7 +19,7 @@ from .decorators.run import run
 from .junit_to_xml import unittest_results_to_xml
 from .logging_config import get_logger
 from .models import McapFixture, ReplayRunParams, RunnerArgs
-from .reader import get_message_mcap_reader, get_sequential_mcap_reader
+from .reader import get_sequential_mcap_reader, read_messages
 from .remote_fixtures import BaseFixture, NexusFixture
 from .replay_runner import ReplayTestingRunner
 
@@ -29,7 +29,7 @@ __all__ = [
     'analyze',
     'ReplayTestingRunner',
     'get_sequential_mcap_reader',
-    'get_message_mcap_reader',
+    'read_messages',
     'McapFixture',
     'ReplayRunParams',
     'RunnerArgs',

--- a/replay_testing/models.py
+++ b/replay_testing/models.py
@@ -17,7 +17,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional
 
-from mcap_ros2.reader import McapReader
+import rosbag2_py
 from pydantic import BaseModel
 
 
@@ -40,7 +40,7 @@ class ReplayRunParams(BaseModel):
 
 class McapFixture(BaseModel):
     path: Path
-    reader: Optional[McapReader] = None
+    reader: Optional[rosbag2_py.SequentialReader] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/replay_testing/replay_fixture.py
+++ b/replay_testing/replay_fixture.py
@@ -17,7 +17,7 @@ import shutil
 from pathlib import Path
 
 from .models import McapFixture
-from .reader import get_message_mcap_reader
+from .reader import get_sequential_mcap_reader
 from .utils import find_mcap_files
 
 # Class responsible for managing all replay fixtures
@@ -50,4 +50,4 @@ class ReplayFixture:
             run_fixture.path = new_path
 
     def initialize_run_reader(self):
-        self.run_fixture.reader = get_message_mcap_reader(self.run_fixture.path)
+        self.run_fixture.reader = get_sequential_mcap_reader(self.run_fixture.path)

--- a/replay_testing/replay_runner.py
+++ b/replay_testing/replay_runner.py
@@ -35,7 +35,7 @@ from .filter import filter_mcap
 from .junit_to_xml import pretty_log_junit_xml, unittest_results_to_xml, write_xml_to_file
 from .logging_config import get_logger
 from .models import McapFixture, ReplayRunParams, ReplayTestingPhase
-from .reader import get_message_mcap_reader, get_sequential_mcap_reader
+from .reader import get_sequential_mcap_reader
 from .remote_fixtures import BaseFixture
 from .replay_fixture import ReplayFixture
 from .replay_test_result import ReplayTestResult
@@ -236,7 +236,7 @@ class ReplayTestingRunner:
             analyze_cls: type[Any] = self._get_stage_class(ReplayTestingPhase.ANALYZE)
 
             for run_fixture in replay_fixture.run_fixtures:
-                reader = get_message_mcap_reader(run_fixture.path)
+                reader = get_sequential_mcap_reader(run_fixture.path)
 
                 class AnalyzeWithReader(analyze_cls):
                     def setUp(inner_self):

--- a/test/replay_tests/basic_replay.py
+++ b/test/replay_tests/basic_replay.py
@@ -15,7 +15,6 @@
 
 import pathlib
 
-import mcap_ros2.reader
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 
@@ -23,6 +22,7 @@ from replay_testing import (
     McapFixture,
     analyze,
     fixtures,
+    read_messages,
     run,
 )
 
@@ -60,8 +60,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+        msgs_it = read_messages(self.reader, topics=['/user/cmd_vel'])
 
-        msgs = [msg for msg in msgs_it]
+        msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == '/user/cmd_vel'
+        assert msgs[0][0] == '/user/cmd_vel'

--- a/test/replay_tests/basic_replay_failure.py
+++ b/test/replay_tests/basic_replay_failure.py
@@ -15,7 +15,6 @@
 
 import pathlib
 
-import mcap_ros2.reader
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 
@@ -23,6 +22,7 @@ from replay_testing import (
     McapFixture,
     analyze,
     fixtures,
+    read_messages,
     run,
 )
 
@@ -60,8 +60,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_expected_failure(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+        msgs_it = read_messages(self.reader, topics=['/user/cmd_vel'])
 
-        msgs = [msg for msg in msgs_it]
+        msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == '/nonexistent/cmd_vel'
+        assert msgs[0][0] == '/nonexistent/cmd_vel'

--- a/test/replay_tests/basic_replay_multiple_fixtures_and_params.py
+++ b/test/replay_tests/basic_replay_multiple_fixtures_and_params.py
@@ -16,7 +16,6 @@
 import json
 from pathlib import Path
 
-import mcap_ros2.reader
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 
@@ -25,6 +24,7 @@ from replay_testing import (
     ReplayRunParams,
     analyze,
     fixtures,
+    read_messages,
     run,
 )
 
@@ -73,8 +73,8 @@ class Run:
 @analyze
 class Analyze:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+        msgs_it = read_messages(self.reader, topics=['/user/cmd_vel'])
 
-        msgs = [msg for msg in msgs_it]
+        msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == '/user/cmd_vel'
+        assert msgs[0][0] == '/user/cmd_vel'

--- a/test/replay_tests/nexus_replay.py
+++ b/test/replay_tests/nexus_replay.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 #
 
-import mcap_ros2.reader
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 
-from replay_testing import NexusFixture, analyze, fixtures, run
+from replay_testing import NexusFixture, analyze, fixtures, read_messages, run
 
 
 @fixtures.parameterize([NexusFixture(path='generic/cmd_vel_only.mcap')])
@@ -51,8 +50,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+        msgs_it = read_messages(self.reader, topics=['/user/cmd_vel'])
 
-        msgs = [msg for msg in msgs_it]
+        msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == '/user/cmd_vel'
+        assert msgs[0][0] == '/user/cmd_vel'

--- a/test/replay_tests/s3_replay.py
+++ b/test/replay_tests/s3_replay.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 #
 
-import mcap_ros2.reader
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 
-from replay_testing import analyze, fixtures, run
+from replay_testing import analyze, fixtures, read_messages, run
 from replay_testing.remote_fixtures import S3Fixture
 
 
@@ -52,8 +51,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+        msgs_it = read_messages(self.reader, topics=['/user/cmd_vel'])
 
-        msgs = [msg for msg in msgs_it]
+        msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == '/user/cmd_vel'
+        assert msgs[0][0] == '/user/cmd_vel'

--- a/test/replay_tests/s3_session_replay.py
+++ b/test/replay_tests/s3_session_replay.py
@@ -16,11 +16,10 @@
 import os
 
 import boto3
-import mcap_ros2.reader
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 
-from replay_testing import analyze, fixtures, run
+from replay_testing import analyze, fixtures, read_messages, run
 from replay_testing.remote_fixtures import S3Fixture
 
 # This example uses the default credential chain (env vars, ~/.aws/credentials, IAM roles, etc.)
@@ -75,8 +74,8 @@ class Run:
 @analyze
 class AnalyzeBasicReplay:
     def test_cmd_vel(self):
-        msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+        msgs_it = read_messages(self.reader, topics=['/user/cmd_vel'])
 
-        msgs = [msg for msg in msgs_it]
+        msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
         assert len(msgs) >= 1
-        assert msgs[0].channel.topic == '/user/cmd_vel'
+        assert msgs[0][0] == '/user/cmd_vel'

--- a/test/test_replay_runner.py
+++ b/test/test_replay_runner.py
@@ -17,7 +17,6 @@ import json
 import types
 from pathlib import Path
 
-import mcap_ros2.reader
 import pytest
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
@@ -28,8 +27,8 @@ from replay_testing import (
     ReplayTestingRunner,
     analyze,
     fixtures,
-    get_message_mcap_reader,
     get_sequential_mcap_reader,
+    read_messages,
     run,
 )
 
@@ -124,12 +123,12 @@ def test_run():
     assert '/vehicle/cmd_vel' in topic_names
     assert '/user/cmd_vel' in topic_names
 
-    msg_reader = get_message_mcap_reader(run_fixture.path)
-    msgs_it = mcap_ros2.reader.read_ros2_messages(msg_reader, topics=['/user/cmd_vel'])
+    msg_reader = get_sequential_mcap_reader(run_fixture.path)
+    msgs_it = read_messages(msg_reader, topics=['/user/cmd_vel'])
 
-    msgs = [msg for msg in msgs_it]
+    msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
     assert len(msgs) >= 1
-    assert msgs[0].channel.topic == '/user/cmd_vel'
+    assert msgs[0][0] == '/user/cmd_vel'
     return
 
 
@@ -165,11 +164,11 @@ def test_analyze():
     @analyze
     class Analyze:
         def test_cmd_vel(self):
-            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+            msgs_it = read_messages(self.reader, topics=['/user/cmd_vel'])
 
-            msgs = [msg for msg in msgs_it]
+            msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
             assert len(msgs) >= 1
-            assert msgs[0].channel.topic == '/user/cmd_vel'
+            assert msgs[0][0] == '/user/cmd_vel'
 
     test_module.Fixtures = Fixtures
     test_module.Run = Run
@@ -266,11 +265,11 @@ def test_multiple_fixtures():
     @analyze
     class Analyze:
         def test_cmd_vel(self):
-            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+            msgs_it = read_messages(self.reader, topics=['/user/cmd_vel'])
 
-            msgs = [msg for msg in msgs_it]
+            msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
             assert len(msgs) >= 1
-            assert msgs[0].channel.topic == '/user/cmd_vel'
+            assert msgs[0][0] == '/user/cmd_vel'
 
     test_module.Fixtures = Fixtures
     test_module.Run = Run
@@ -333,11 +332,11 @@ def test_parametric_sweep():
     @analyze
     class Analyze:
         def test_cmd_vel(self):
-            msgs_it = mcap_ros2.reader.read_ros2_messages(self.reader, topics=['/user/cmd_vel'])
+            msgs_it = read_messages(self.reader, topics=['/user/cmd_vel'])
 
-            msgs = [msg for msg in msgs_it]
+            msgs = [(topic_name, msg, timestamp) for topic_name, msg, timestamp in msgs_it]
             assert len(msgs) >= 1
-            assert msgs[0].channel.topic == '/user/cmd_vel'
+            assert msgs[0][0] == '/user/cmd_vel'
 
     test_module.Fixtures = Fixtures
     test_module.Run = Run


### PR DESCRIPTION
Closes #2.

Replacing with native ROS2 rclpy tooling for reading messages. Was pretty 1-for-1 with previous methodology.

I'd love to include some more helpers here for the `@analyze` step down the line. TBD.