### PR TITLE
Buildfarm fix

### DIFF
--- a/replay_testing/replay_runner.py
+++ b/replay_testing/replay_runner.py
@@ -56,7 +56,12 @@ class ReplayTestingRunner:
             self._test_run_uuid = uuid.uuid4()
 
         # For Gitlab CI. TODO(troy): This should just be an env variable set by .gitlab-ci.yml
-        result_base = Path('test_results') if os.environ.get('CI') else Path(tempfile.gettempdir())
+        _logger_.info(f'Replay User: {os.environ.get("USER")}, CI: {os.environ.get("CI")}')
+        result_base = (
+            Path('test_results')
+            if os.environ.get('CI') or os.environ.get('USER') == 'buildfarm'
+            else Path(tempfile.gettempdir())
+        )
         self._replay_directory = result_base / 'replay_testing'
         self._replay_results_directory = self._replay_directory / str(self._test_run_uuid)
 


### PR DESCRIPTION
## Description

Attempt number one of trying to [fix the following error](https://build.ros2.org/job/Jdev__replay_testing__ubuntu_noble_amd64/16/console):

```
15:21:59 1:         if not os.access(self._replay_directory, os.W_OK):
15:21:59 1: >           raise PermissionError(f'No write permission for directory: {self._replay_directory}')
15:21:59 1: E           PermissionError: No write permission for directory: /tmp/replay_testing
```

Need some env variable to figure out if we're in the buildfarm or not. Generally it is more useful to dump replay assets in `/tmp` but we'll see how this goes. 