### PR TITLE
Allow passing extra arguments to test runs

### DIFF
--- a/replay_testing/cli.py
+++ b/replay_testing/cli.py
@@ -123,7 +123,11 @@ def add_arguments(parser):
 def parse_arguments():
     parser = argparse.ArgumentParser(description='replay integration testing tool.')
     add_arguments(parser)
-    return parser, parser.parse_args()
+    # Use parse_known_args to allow extra arguments to pass through to the test file
+    args, unknown = parser.parse_known_args()
+    # Store unknown args for potential use by test files
+    args.unknown_args = unknown
+    return parser, args
 
 
 def run(parser, args):


### PR DESCRIPTION
Hi! Thanks a lot for open sourcing this package!

I was setting up some tests involving nav2 costmaps and wanted to expose an argument to chose wether to launch rviz on nav2's launch. This is useful in my case because I want to debug the tests while i create them, but don't want to use rviz when running on my CI system.

I modified the cli to support this. 

Sorry in advance if there's already a way of doing this that I missed.